### PR TITLE
Remove styles for buttons that depend on order in flow

### DIFF
--- a/bipp.css
+++ b/bipp.css
@@ -235,22 +235,6 @@ button {
 	transition: transform .1s;
 }
 
-button:nth-child(n) {
-	background-color: var(--c-red);
-}
-
-button:nth-child(2n) {
-	background-color: var(--c-green);
-}
-
-button:nth-child(3n) {
-	background-color: var(--c-yellow);
-}
-
-button:nth-child(4n) {
-	background-color: var(--c-blue);
-}
-
 button::before {
 	display: inline-block;
 	content: '';


### PR DESCRIPTION
Данные стили написаны под дэмо-страницу, но при использовании bipp как зависимости они мешают.